### PR TITLE
Workaround for the wrong source folder marking of the idea gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,26 @@ allprojects {
 
         compile 'mysql:mysql-connector-java:6.0.6'
     }
+	
+	idea{
+	module.iml.withXml {
+        def node = it.asNode()
+        def content = node.component.find { it.'@name' == 'NewModuleRootManager' }.content[0]
+        content.sourceFolder.each { sourceFolder ->
+            if(sourceFolder.@url?.endsWith('/resources')) {
+                sourceFolder.attributes().with {
+                    put('type', 'java-resource')
+                }
+            }
+			if(sourceFolder.@url?.endsWith('/test/java')) {
+                sourceFolder.attributes().with {
+                    put('isTestSource', 'true')
+                }
+            }
+        }
+    }
+	}
+	
 }
 
 dependencies {


### PR DESCRIPTION
I couldn't find another way to fix the wrong root source folder marking.
This fix is modifying the created .iml file and applies the default java folder marking to it.,